### PR TITLE
feat: 이슈 리스트와 광고 배너에 대한 무한 스크롤 기능 추가 및 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "wanted-internship-1",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",

--- a/src/api/hook/useFetchInitialData.ts
+++ b/src/api/hook/useFetchInitialData.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react'
+import { CORE_API } from '../../api/core'
+import { OWNER, REPO } from '../../api/constants'
+import { sortingIsOpen } from '../../util/sortingIsOpen'
+import { sortingComments } from '../../util/sortingComments'
+import { IssueDataType } from '../../util/type'
+
+const useFetchInitialData = (
+  setIssueCard: React.Dispatch<React.SetStateAction<IssueDataType[]>>,
+) => {
+  useEffect(() => {
+    const fetchIssueData = async () => {
+      try {
+        const response = await CORE_API('get', `/repos/${OWNER}/${REPO}/issues`, {
+          page: 1,
+          sort: 'comments',
+        })
+        const { data } = response
+
+        const sortedIsOpen = sortingIsOpen(data)
+        const sortedData = sortingComments(sortedIsOpen)
+
+        setIssueCard(prev => [...prev, ...sortedData])
+      } catch (error) {
+        console.log(error)
+      }
+    }
+
+    fetchIssueData()
+  }, [])
+}
+
+export default useFetchInitialData

--- a/src/api/hook/useFetchNextPage.ts
+++ b/src/api/hook/useFetchNextPage.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState, useEffect } from 'react'
+import { CORE_API } from '../core'
+import { OWNER, REPO } from '../constants'
+import { sortingIsOpen } from '../../util/sortingIsOpen'
+import { sortingComments } from '../../util/sortingComments'
+import { IssueDataType } from '../../util/type'
+
+const useFetchNextPage = (setIssueCard: React.Dispatch<React.SetStateAction<IssueDataType[]>>) => {
+  const [pageToFetch, setPageToFetch] = useState(1) // 페이지 번호를 별도의 상태로 관리합니다.
+
+  const fetchNextPage = useCallback(
+    async () => {
+      try {
+        const response = await CORE_API('get', `/repos/${OWNER}/${REPO}/issues`, {
+          page: pageToFetch,
+          sort: 'comments',
+        })
+        const { data } = response
+
+        const sortedIsOpen = sortingIsOpen(data)
+        const sortedData = sortingComments(sortedIsOpen)
+
+        setIssueCard((prev: IssueDataType[]) => [...prev, ...sortedData])
+      } catch (error) {
+        console.log(error)
+      }
+    },
+    [setIssueCard, pageToFetch], // 의존성 배열에 'pageToFetch' 추가
+  )
+
+  useEffect(() => {
+    if (pageToFetch > 1) fetchNextPage() // 페이지 번호가 변경될 때마다 데이터를 불러옵니다.
+  }, [pageToFetch]) // 의존성 배열에 'pageToFetch' 추가
+
+  return setPageToFetch // 페이지 번호 설정 함수 반환
+}
+
+export default useFetchNextPage

--- a/src/components/main/hook/useInfiniteScrollIssues.tsx
+++ b/src/components/main/hook/useInfiniteScrollIssues.tsx
@@ -1,0 +1,28 @@
+import { useRef, useState, useEffect, useCallback } from 'react'
+import useFetchNextPage from '../../../api/hook/useFetchNextPage'
+import { IssueDataType } from '../../../util/type'
+
+const useInfiniteScrollIssues = (
+  setIssueCard: React.Dispatch<React.SetStateAction<IssueDataType[]>>,
+) => {
+  const observer = useRef<IntersectionObserver | null>(null)
+
+  const setPageToFetch = useFetchNextPage(setIssueCard)
+
+  const lastIssueRefCallback = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (observer.current) observer.current.disconnect()
+
+      observer.current = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting) setPageToFetch(prevPage => prevPage + 1)
+      })
+
+      if (node) observer.current.observe(node)
+    },
+    [setPageToFetch],
+  )
+
+  return lastIssueRefCallback
+}
+
+export default useInfiniteScrollIssues


### PR DESCRIPTION

## 분류

- [ v] 버그 수정
- [ v] 신규 기능 추가
- [ v] 리팩토링
- [ ] 디자인
- [ ] 코드포메팅

## 상세내용

- 5번째 인덱스가 사라지는 현상 수정 (5번째 차례마다 광고가 그 자리를 차지하고 있었음)
- 무한 스크롤 기능 구현
- useFetchInitialData, useFetchNextPage 함수 추가로 코드 가독성 향상
- Props 정리로 가독성 향상